### PR TITLE
byungmin : 마이페이지 챌린지 조회 로직 구현

### DIFF
--- a/src/main/java/com/example/shortform/controller/UserApiController.java
+++ b/src/main/java/com/example/shortform/controller/UserApiController.java
@@ -5,9 +5,11 @@ import com.example.shortform.config.jwt.TokenDto;
 import com.example.shortform.dto.request.*;
 import com.example.shortform.dto.resonse.CMResponseDto;
 
+import com.example.shortform.dto.resonse.UserChallengeInfo;
 import com.example.shortform.dto.resonse.UserInfo;
 import com.example.shortform.dto.resonse.UserProfileInfo;
 import com.example.shortform.exception.NotFoundException;
+import com.example.shortform.service.ChallengeService;
 import com.example.shortform.service.KakaoService;
 import com.example.shortform.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.io.IOException;
+import java.text.ParseException;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -25,6 +29,7 @@ public class UserApiController {
 
     private final UserService userService;
     private final KakaoService kakaoService;
+    private final ChallengeService challengeService;
 
     // 회원가입
     @PostMapping("/auth/signup")
@@ -111,5 +116,10 @@ public class UserApiController {
         return ResponseEntity.ok(userService.getUserProfile(userId));
     }
 
+    // 유저 챌린지 조회
+    @GetMapping("/mypage/challenge/{userId}")
+    public ResponseEntity<List<UserChallengeInfo>> getUserChallenge(@PathVariable Long userId) throws ParseException {
+        return challengeService.getUserChallenge(userId);
+    }
 }
 

--- a/src/main/java/com/example/shortform/domain/UserChallenge.java
+++ b/src/main/java/com/example/shortform/domain/UserChallenge.java
@@ -1,8 +1,11 @@
 package com.example.shortform.domain;
 
+import com.example.shortform.exception.InvalidException;
 import lombok.*;
 
 import javax.persistence.*;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 @Builder
@@ -13,7 +16,7 @@ import java.util.*;
 @Entity
 public class UserChallenge extends Timestamped{
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     private Long id;
 
@@ -25,9 +28,37 @@ public class UserChallenge extends Timestamped{
     @JoinColumn(name = "challenge_id")
     private Challenge challenge;
 
+    // 챌린지 일수
+    private int challengeDate;
+
+    // 당일 인증 여부(성공하면 내가 해냄)
+    private boolean dailyAuthenticated;
+
+    // 인증 갯수
+    private int authCount;
 
     public UserChallenge(Challenge challenge, User user) {
         this.challenge = challenge;
         this.user = user;
+        this.challengeDate = getChallengeDate(challenge);
+        this.dailyAuthenticated = false;
+        this.authCount = 0;
+    }
+
+    private int getChallengeDate(Challenge challenge) {
+        String date1 = challenge.getEndDate().split(" ")[0];
+        String date2 = challenge.getStartDate().split(" ")[0];
+
+        try {
+            Date format1 = new SimpleDateFormat("yyyy.MM.dd").parse(date1);
+            Date format2 = new SimpleDateFormat("yyyy.MM.dd").parse(date2);
+
+            long diffSec = (format1.getTime() - format2.getTime()) / 1000;
+            long diffDays = diffSec / (24 * 60 * 60);
+
+            return (int) diffDays + 1;
+        } catch (ParseException e) {
+            throw new InvalidException("날짜 형식이 잘못되었습니다.");
+        }
     }
 }

--- a/src/main/java/com/example/shortform/dto/resonse/UserChallengeInfo.java
+++ b/src/main/java/com/example/shortform/dto/resonse/UserChallengeInfo.java
@@ -1,0 +1,49 @@
+package com.example.shortform.dto.resonse;
+
+import com.example.shortform.domain.Challenge;
+import com.example.shortform.domain.Post;
+import com.example.shortform.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserChallengeInfo {
+
+    private Long userId;
+
+    private Long challengeId;
+
+    private String title;
+    private String category;
+    private List<String> challengeImage;
+    private int maxMember;
+    private int currentMember;
+    private String startDate; //LocalDate
+    private String endDate; //LocalDate
+    private Boolean isPrivate;
+    private List<String> tagName;
+    private String status;
+    private String dailyAuth;
+
+    public static UserChallengeInfo of(Challenge challenge, String status,
+                                       List<String> tagChallengeStrings, List<String> challengeImages, String dailyAuth) {
+        return UserChallengeInfo.builder()
+                .userId(challenge.getUser().getId())
+                .challengeId(challenge.getId())
+                .title(challenge.getTitle())
+                .category(challenge.getCategory().getName())
+                .challengeImage(challengeImages)
+                .maxMember(challenge.getMaxMember())
+                .currentMember(challenge.getCurrentMember())
+                .startDate(challenge.getStartDate())
+                .endDate(challenge.getEndDate())
+                .isPrivate(challenge.getIsPrivate())
+                .tagName(tagChallengeStrings)
+                .status(status)
+                .dailyAuth(dailyAuth)
+                .build();
+    };
+}

--- a/src/main/java/com/example/shortform/repository/UserChallengeRepository.java
+++ b/src/main/java/com/example/shortform/repository/UserChallengeRepository.java
@@ -4,6 +4,8 @@ import com.example.shortform.domain.Challenge;
 import com.example.shortform.domain.User;
 import com.example.shortform.domain.UserChallenge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,4 +14,11 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     UserChallenge findByUserIdAndChallengeId(Long id, Long challengeId);
 
     void deleteByUserIdAndChallengeId(Long id, Long challengeId);
+
+    @Query("select uc from UserChallenge uc " +
+            "inner join fetch uc.challenge " +
+            "inner join fetch uc.user " +
+            "where uc.user.id = :user_id " +
+            "order by uc.challenge.createdAt desc ")
+    List<UserChallenge> findAllUserChallengeInfo(@Param("user_id") Long user_id);
 }

--- a/src/main/java/com/example/shortform/service/ChallengeService.java
+++ b/src/main/java/com/example/shortform/service/ChallengeService.java
@@ -10,6 +10,7 @@ import com.example.shortform.dto.request.ChallengeModifyRequestDto;
 import com.example.shortform.dto.request.PasswordDto;
 import com.example.shortform.dto.resonse.CMResponseDto;
 import com.example.shortform.dto.resonse.MemberResponseDto;
+import com.example.shortform.dto.resonse.UserChallengeInfo;
 import com.example.shortform.exception.*;
 import com.example.shortform.repository.*;
 import lombok.RequiredArgsConstructor;
@@ -398,5 +399,63 @@ public class ChallengeService {
         challengeRepository.delete(challenge);
 
         return ResponseEntity.ok(new CMResponseDto("true"));
+    }
+
+    @org.springframework.transaction.annotation.Transactional(readOnly = true)
+    public ResponseEntity<List<UserChallengeInfo>> getUserChallenge(Long userId) throws ParseException {
+        User findUser = userRepository.findUserInfo(userId).orElseThrow(
+                () -> new NotFoundException("존재하지 않는 유저입니다.")
+        );
+
+        List<UserChallenge> UserChallengeInfoList = userChallengeRepository.findAllUserChallengeInfo(findUser.getId());
+        List<UserChallengeInfo> userChallengeInfoList = new ArrayList<>();
+
+        for (UserChallenge userChallenge : UserChallengeInfoList) {
+
+            // challenge
+            Challenge challenge = userChallenge.getChallenge();
+            // status
+            String status = challengeStatus(challenge);
+
+            String dailyAuth = null;
+            // 진행중 챌린지 : 포스트 인증하면 내가 해냄 리턴해주기
+            if (userChallenge.isDailyAuthenticated())
+                dailyAuth = "true";
+            else
+                dailyAuth = "false";
+
+            // 완료된 챌린지에서 성공, 실패 리턴해주기
+            if ("완료".equals(status)) {
+                // 성공일수(챌린지 진행일 * 0.8) > 인증횟수
+                if ((int)Math.ceil(userChallenge.getChallengeDate() * 0.8) > userChallenge.getAuthCount())
+                    status = "실패";
+                // 인증횟수가 같거나 더 많으면 성공
+                else
+                    status = "성공";
+            }
+
+            // tag
+            List<String> tagChallengeStrings = new ArrayList<>();
+            List<TagChallenge> tagChallenges = challenge.getTagChallenges();
+            for(TagChallenge tagChallenge : tagChallenges){
+                String tagChallengeString = tagChallenge.getTag().getName();
+                tagChallengeStrings.add(tagChallengeString);
+            }
+
+            // image
+            List<String> challengeImages = new ArrayList<>();
+            List<ImageFile> ImageFiles =  challenge.getChallengeImage();
+            for(ImageFile image:ImageFiles){
+                challengeImages.add(image.getFilePath());
+            }
+
+            UserChallengeInfo userChallengeInfo = UserChallengeInfo.of(challenge, status, tagChallengeStrings,
+                    challengeImages, dailyAuth);
+
+            userChallengeInfoList.add(userChallengeInfo);
+        }
+
+        return ResponseEntity.ok(userChallengeInfoList);
+
     }
 }

--- a/src/main/java/com/example/shortform/service/RankingService.java
+++ b/src/main/java/com/example/shortform/service/RankingService.java
@@ -3,10 +3,12 @@ package com.example.shortform.service;
 import com.example.shortform.config.auth.PrincipalDetails;
 import com.example.shortform.domain.Ranking;
 import com.example.shortform.domain.User;
+import com.example.shortform.domain.UserChallenge;
 import com.example.shortform.dto.RequestDto.RankingRequestDto;
 import com.example.shortform.dto.ResponseDto.RankingResponseDto;
 import com.example.shortform.exception.NotFoundException;
 import com.example.shortform.repository.RankingRepository;
+import com.example.shortform.repository.UserChallengeRepository;
 import com.example.shortform.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -25,6 +27,7 @@ public class RankingService {
 
     private final RankingRepository rankRepository;
     private final UserRepository userRepository;
+    private final UserChallengeRepository userChallengeRepository;
 
     @Scheduled(cron = "0 0 0 * * *")//fixedDelay = 1000 * 60 * 60 * 24)
     public void updateRank(){
@@ -32,6 +35,12 @@ public class RankingService {
         Ranking rank = new Ranking(users);
         rankRepository.save(rank);
 
+        // 12시 마다 데일리 인증 초기화해주기
+        List<UserChallenge> userChallenges = userChallengeRepository.findAll();
+        for (UserChallenge userChallenge : userChallenges) {
+            userChallenge.setDailyAuthenticated(false);
+            userChallengeRepository.save(userChallenge);
+        }
     }
 
     public List<RankingResponseDto> getRanking(PrincipalDetails principalDetails){


### PR DESCRIPTION
마이페이지에서 사용자별 챌린지 조회 로직 구현했습니다.

1. UserChallenge 테이블에 각각 
challengeDate(해당 챌린지 진행일), dailyAuthenticated(당일 인증 여부), authCount(인증 갯수) 컬럼 추가했습니다.

2. 챌린지에 게시글 등록 시 userChallenge 테이블의 authCount가 1씩 증가하고 dailyAuthenticated가 true가 됩니다.
3. 챌린지에 게시글 삭제 시 userChallenge 테이블의 authCount가 1씩 감소하고 dailyAuthenticated가 false가 됩니다.
4. 매일 0시에 인증게시글 성공 여부(dailyAuthenticated) false로 설정 :  RankingService에 혜원님이 만들어놓은 스케줄에 로직 같이 추가했습니다.